### PR TITLE
A few bug fixes and minor changes to output and exit status

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ For a short tutorial (To be completed) check [here](http://deslogin.cosmology.il
 
 ### Running SQL commands
 Once inside the interpreter run SQL queries by adding a ; at the end::
-
         DESDB ~> select ... from ... where ... ;
-
 To save the results into a table add ">" after the end of the query (after ";") and namefile at the end of line
 
         DESDB ~> select ... from ... where ... ; > test.fits

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For a short tutorial (To be completed) check [here](http://deslogin.cosmology.il
 
 Assuming that ```easyaccess``` is in your path, you can enter the interactive interpreter by calling ```easyaccess``` without any command line arguments:
 
-    easyaccess
+        easyaccess
 
 ### Running SQL commands
 Once inside the interpreter run SQL queries by adding a ";" at the end::
@@ -60,28 +60,22 @@ The file types supported so far are: .csv, .tab, .fits, and .h5. Any other exten
 To load a table it needs to be in a csv format with columns names in the first row
 the name of the table is taken from filename
 
-
         DESDB ~> load_table <filename>
 
 ### Load SQL queries
-To load sql queries just run:
+To load SQL queries just run:
 
         DESDB ~> loadsql <filename.sql>
 or
 
         DESDB ~> @filename.sql
 
-The format is the same as in command line, SQL statement must end with ;
-and to write output files it must be followed by > <output file>
+The query format is the same as the interpreter, SQL statement must end with ";" and to write output files the query must be followed by " > <output file>"
 
 ### Configuration
 
-The configuration file is located at $HOME/.easyaccess/config.ini
+The configuration file is located at $HOME/.easyaccess/config.ini but everything can be configured from inside easyaccess type:
 
-but everything can be configured from inside easyaccess
-
-type:
-   
         DESDB ~> help config
         
 to see the meanings of all the options, and:
@@ -98,10 +92,9 @@ and to see any particular option (e.g., timeout):
 
 ## Command-line usage
 
-Much of the same functionality provided through the interpreter is also available directly from the command line. To see a list of command-line options, use the "--help" option
+Much of the functionality provided through the interpreter is also available directly from the command line. To see a list of command-line options, use the "--help" option
 
-    easyaccess --help
-
+        easyaccess --help
 
 ## TODO
     - There is a bug with some versions of readline

--- a/README.md
+++ b/README.md
@@ -37,16 +37,24 @@ For a short tutorial (To be completed) check [here](http://deslogin.cosmology.il
 - Show the execution plan of a query if required
 - Many more
 
-## Basic use
+
+    
+## Interactive interpreter
+
+Assuming that ```easyaccess``` is in your path, you can enter the interactive interpreter by calling ```easyaccess``` without any command line arguments:
+
+    easyaccess
 
 ### Running SQL commands
-Once inside the interpreter run SQL queries by adding a ; at the end::
+Once inside the interpreter run SQL queries by adding a ";" at the end::
+
         DESDB ~> select ... from ... where ... ;
+
 To save the results into a table add ">" after the end of the query (after ";") and namefile at the end of line
 
         DESDB ~> select ... from ... where ... ; > test.fits
 
-The files supported so far are (.csv, .tab, .fits, .h5) any other extension is ignored
+The file types supported so far are: .csv, .tab, .fits, and .h5. Any other extension is ignored.
 
 ### Load tables
 To load a table it needs to be in a csv format with columns names in the first row
@@ -88,8 +96,14 @@ and to see any particular option (e.g., timeout):
 
         DESDB ~> config timeout show
 
+## Command-line usage
 
-### TODO
+Much of the same functionality provided through the interpreter is also available directly from the command line. To see a list of command-line options, use the "--help" option
+
+    easyaccess --help
+
+
+## TODO
     - There is a bug with some versions of readline
     - Other small changes when loading tables
     - Self-upgrade

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The query format is the same as the interpreter, SQL statement must end with ";"
 
 ### Configuration
 
-The configuration file is located at $HOME/.easyaccess/config.ini but everything can be configured from inside easyaccess type:
+The configuration file is located at ```$HOME/.easyaccess/config.ini``` but everything can be configured from inside easyaccess type:
 
         DESDB ~> help config
         
@@ -92,7 +92,7 @@ and to see any particular option (e.g., timeout):
 
 ## Command-line usage
 
-Much of the functionality provided through the interpreter is also available directly from the command line. To see a list of command-line options, use the "--help" option
+Much of the functionality provided through the interpreter is also available directly from the command line. To see a list of command-line options, use the ```--help``` option
 
         easyaccess --help
 
@@ -100,3 +100,4 @@ Much of the functionality provided through the interpreter is also available dir
     - There is a bug with some versions of readline
     - Other small changes when loading tables
     - Self-upgrade
+    - Refactor the code so that it isn't in one huge file

--- a/config_ea.py
+++ b/config_ea.py
@@ -5,11 +5,11 @@ from __future__ import print_function
 # For compatibility with old python
 try:
     from builtins import input, range
+    import configparser
 except ImportError:
     from __builtin__ import input, range
+    import ConfigParser as configparser
 
-# Config file
-import configparser
 import getpass
 import sys
 import cx_Oracle

--- a/config_ea.py
+++ b/config_ea.py
@@ -1,8 +1,13 @@
 from __future__ import print_function
 #from future import standard_library
 #standard_library.install_aliases()
-from builtins import input
-from builtins import range
+
+# For compatibility with old python
+try:
+    from builtins import input, range
+except ImportError:
+    from __builtin__ import input, range
+
 # Config file
 import configparser
 import getpass

--- a/easyaccess.py
+++ b/easyaccess.py
@@ -5,9 +5,11 @@ from __future__ import absolute_import
 
 __author__ = 'Matias Carrasco Kind'
 __version__ = '1.2.0'
-from builtins import input
-from builtins import str
-from builtins import range
+try:
+    from builtins import input, str, range
+except ImportError:
+    from __builtin__ import input, str, range
+
 import warnings
 
 warnings.filterwarnings("ignore")
@@ -336,6 +338,7 @@ class easy_or(cmd.Cmd, object):
         kwargs = {'host': self.dbhost, 'port': self.port, 'service_name': self.dbname}
         self.dsn = cx_Oracle.makedsn(**kwargs)
         if not self.quiet: print('Connecting to DB ** %s ** ...' % self.dbname)
+        #if not self.quiet: sys.stdout.write('Connecting to DB ** %s ** ...' % self.dbname)
         connected = False
         for tries in range(3):
             try:
@@ -1285,8 +1288,9 @@ class easy_or(cmd.Cmd, object):
         """
         # TODO: platform dependent
         # tmp = sp.call('clear', shell=True)
-        tmp = os.system(['clear', 'cls'][os.name == 'nt'])
-
+        sys.stdout.flush()
+        #tmp = os.system(['clear', 'cls'][os.name == 'nt'])
+        pass
 
     def do_config(self, line):
         """
@@ -2307,27 +2311,25 @@ if __name__ == '__main__':
         initial_message(args.quiet, clear=False)
         cmdinterp = easy_or(conf, desconf, db, interactive=False, quiet=args.quiet)
         cmdinterp.onecmd(args.command)
-        os._exit(0)
+        sys.exit(0) #os._exit(0)
     elif args.loadsql is not None:
         initial_message(args.quiet, clear=False)
         cmdinterp = easy_or(conf, desconf, db, interactive=False, quiet=args.quiet)
         linein = "loadsql " + args.loadsql
         cmdinterp.onecmd(linein)
-        os._exit(0)
+        sys.exit(0) #os._exit(0)
     elif args.loadtable is not None:
         initial_message(args.quiet, clear=False)
         cmdinterp = easy_or(conf, desconf, db, interactive=False, quiet=args.quiet)
         linein = "load_table " + args.loadtable
         cmdinterp.onecmd(linein)
-        os._exit(0)
+        sys.exit(0) #os._exit(0)
     elif args.appendtable is not None:
         initial_message(args.quiet, clear=False)
         cmdinterp = easy_or(conf, desconf, db, interactive=False, quiet=args.quiet)
         linein = "append_table " + args.appendtable
         cmdinterp.onecmd(linein)
-        os._exit(0)
+        sys.exit(0) #os._exit(0)
     else:
         initial_message(args.quiet, clear=True)
         easy_or(conf, desconf, db, quiet=args.quiet).cmdloop()
-
-

--- a/easyaccess.py
+++ b/easyaccess.py
@@ -59,7 +59,7 @@ config_file = os.path.join(os.environ["HOME"], ".easyaccess/config.ini")
 
 # check if old path is there
 ea_path_old = os.path.join(os.environ["HOME"], ".easyacess/")
-if os.path.exists(ea_path_old):
+if os.path.exists(ea_path_old) and os.path.isdir(ea_path_old):
     if not os.path.exists(history_file):
         shutil.copy2(os.path.join(os.environ["HOME"], ".easyacess/history"), history_file)
     if not os.path.exists(config_file):
@@ -2313,25 +2313,25 @@ if __name__ == '__main__':
         initial_message(args.quiet, clear=False)
         cmdinterp = easy_or(conf, desconf, db, interactive=False, quiet=args.quiet)
         cmdinterp.onecmd(args.command)
-        sys.exit(0) #os._exit(0)
+        os._exit(0)
     elif args.loadsql is not None:
         initial_message(args.quiet, clear=False)
         cmdinterp = easy_or(conf, desconf, db, interactive=False, quiet=args.quiet)
         linein = "loadsql " + args.loadsql
         cmdinterp.onecmd(linein)
-        sys.exit(0) #os._exit(0)
+        os._exit(0)
     elif args.loadtable is not None:
         initial_message(args.quiet, clear=False)
         cmdinterp = easy_or(conf, desconf, db, interactive=False, quiet=args.quiet)
         linein = "load_table " + args.loadtable
         cmdinterp.onecmd(linein)
-        sys.exit(0) #os._exit(0)
+        os._exit(0)
     elif args.appendtable is not None:
         initial_message(args.quiet, clear=False)
         cmdinterp = easy_or(conf, desconf, db, interactive=False, quiet=args.quiet)
         linein = "append_table " + args.appendtable
         cmdinterp.onecmd(linein)
-        sys.exit(0) #os._exit(0)
+        os._exit(0)
     else:
         initial_message(args.quiet, clear=True)
         easy_or(conf, desconf, db, quiet=args.quiet).cmdloop()

--- a/easyaccess.py
+++ b/easyaccess.py
@@ -1579,7 +1579,7 @@ class easy_or(cmd.Cmd, object):
 
     def do_describe_table(self, arg, clear=True):
         """
-        DB:This tool is useful in noting the lack of documentation for the
+        DB: This tool is useful in noting the lack of documentation for the
         columns. If you don't know the full table name you can use tab
         completion on the table name. Tables of usual interest are described
 
@@ -2016,16 +2016,17 @@ class easy_or(cmd.Cmd, object):
 
     def do_add_comment(self, line):
         """
-        DB:Add comments to table and/or columns inside tables
+        DB: Add comments to table and/or columns inside tables
 
         Usage: 
-            - add_comment table <TABLE> 'Comments on table"
-            - add_comment column <TABLE.COLUMN> 'Comments on columns"
+            - add_comment table <TABLE> 'Comments on table'
+            - add_comment column <TABLE.COLUMN> 'Comments on columns'
 
-        Ex:  add_comment table MY_TABLE 'This table contains info"
-             add_comment columns MY_TABLE.ID 'Id for my objects"
+        Ex:  add_comment table MY_TABLE 'This table contains info'
+             add_comment columns MY_TABLE.ID 'Id for my objects'
 
-        This command support smart-autocompletion
+        This command supports smart-autocompletion. No `;` is 
+        necessary (and it will be inserted into comment if used).
 
         """
 

--- a/easyaccess.py
+++ b/easyaccess.py
@@ -359,7 +359,7 @@ class easy_or(cmd.Cmd, object):
         self.cur = self.con.cursor()
         self.cur.arraysize = self.prefetch
         msg = self.last_pass_changed()
-        if msg: print(msg)
+        if msg and not self.quiet: print(msg)
 
 
     def handler(self, signum, frame):
@@ -782,7 +782,6 @@ class easy_or(cmd.Cmd, object):
 
     # ## QUERY METHODS
 
-
     def last_pass_changed(self):
         """
         Return creation time and last time password was modified
@@ -800,8 +799,8 @@ class easy_or(cmd.Cmd, object):
             msg = colored("*Important* ", "red") + 'Last time password change was ' + colored("%d" % ptime,
                                                                                               "red") + " days ago"
             if ptime == ctime: msg += colored(" (Never in your case!)", "red")
-            msg += '\n Please change it soon using the ' + colored("set_password",
-                                                                   "cyan") + ' command and you will get rid of this message\n'
+            msg += '\n Please change it using the ' + colored("set_password",
+                                                                   "cyan") + ' command to get rid of this message\n'
             return msg
 
 
@@ -1823,7 +1822,7 @@ class easy_or(cmd.Cmd, object):
                 raise Exception(msg)
             # Monkey patch to grab columns and values
             DF.ea_get_columns = DF.columns.values.tolist
-            DF.eag_get_values = DF.values.tolist
+            DF.ea_get_values = DF.values.tolist
         elif format in ('fits', 'fit'):
             try:
                 DF = fitsio.FITS(filename)
@@ -2196,13 +2195,13 @@ class connect(easy_or):
         """
         List tables in own schema
         """
-        self.do_mytables('', clear=False)
+        self.do_mytables('')
 
     def myquota(self):
         """
         Show quota in current database
         """
-        self.do_myquota('', clear=False)
+        self.do_myquota('')
 
     def load_table(self, table_file, name=''):
         """

--- a/easyaccess.py
+++ b/easyaccess.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import
 
 __author__ = 'Matias Carrasco Kind'
 __version__ = '1.2.0'
+
+# For compatibility with old python
 try:
     from builtins import input, str, range
 except ImportError:


### PR DESCRIPTION
Fixes a few small bugs that were introduced in the latest update (removing  the "clear" option from several commands). I also found myself running several instances of `easyaccess` and wanting to create log files. It turned out that the way `easyaccess` was exiting with `os._exit(0)` was causing problems (http://stackoverflow.com/a/9591397/4075339). The use of `os._exit` was probably originally intended to deal with the forked progress bar; however, I haven't noticed any negative effect from changing to `sys.exit`.
