### PR TITLE
Dereferencing tablenames (1.2.0br2)

### DIFF
--- a/easyaccess.py
+++ b/easyaccess.py
@@ -1589,7 +1589,7 @@ class easy_or(cmd.Cmd, object):
         else:
             return options_users
 
-    def get_real_table(self, tablename):
+    def get_tablename_tuple(self, tablename):
         """
         Return the tuple (schema,table,link) that can be used to
         locate the `real` table requested.
@@ -1681,7 +1681,7 @@ class easy_or(cmd.Cmd, object):
             pass
 
         try: 
-            schema,table,link = self.get_real_table(tablename)
+            schema,table,link = self.get_tablename_tuple(tablename)
             # schema, table and link are now valid.
             link = "@" + link if link else ""
             qcom = """ 
@@ -1786,7 +1786,7 @@ class easy_or(cmd.Cmd, object):
         tablename = tablename.upper()
 
         try: 
-            schema,table,link = self.get_real_table(tablename)
+            schema,table,link = self.get_tablename_tuple(tablename)
             link = "@" + link if link else ""
         except: 
             print(colored("Table not found.", "red"))


### PR DESCRIPTION
Extracted the functionality for breaking a tablename into a (schema,table,link) tuple. This is used by `show_index` and `describe_table`. Addresses #40
