### PR TITLE
Correcting issue with i8 conversion

### DIFF
--- a/easyaccess/eautils/dtypes.py
+++ b/easyaccess/eautils/dtypes.py
@@ -45,17 +45,16 @@ def oracle2numpy(desc):
     size = desc[3]
     digits = desc[4]
     scale = desc[5]
-    
+
     if otype == or_n:
-        if scale == 0:
+        if scale == 0 and digits != 0:
             # Nothing after the decimal; integers
-            if digits == 0:
-                return "i8"
-            elif digits <= 4:
+            if digits <= 4:
                 return "i2"
             elif digits <= 9:
                 return "i4"
-            elif digits <= 18:
+            # This is sloppy...
+            else:
                 return "i8"
         else:
             # Otherwise, floats
@@ -135,8 +134,9 @@ def numpy2oracle(dtype):
             return 'NUMBER(10,0)'
         else:
             # 8-byte (64 bit) integer
+            # This is sloppy...
             # 'i8' is 19 digits; 'u8' is 20 digits
-            return 'NUMBER'
+            return 'NUMBER(20,0)'
     elif (kind == 'f'):
         if (size == 4):
             # 4-byte (32 bit) float


### PR DESCRIPTION
Trying to correct some of the issues in type conversion, specifically for large integers which were setting oracle type NUMBER. Specifying NUMBER without a scale or precision leads to problems down the road when trying to convert back to a numpy type. This does not completely address the issues commented on in pull request #56.
