### PR TITLE
Adding conda build files

### DIFF
--- a/config/conda/bld.bat
+++ b/config/conda/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/config/conda/build.sh
+++ b/config/conda/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/config/conda/meta.yaml
+++ b/config/conda/meta.yaml
@@ -1,0 +1,41 @@
+package:
+  name: easyaccess
+  version: "1.2.1b"
+
+source:
+  git_rev: '1.2.1b'
+  git_url: https://github.com/mgckind/easyaccess
+  
+
+build:
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - future
+    - termcolor
+    - fitsio
+    - pandas >=0.14
+    - oracle-instantclient
+    - cx_oracle
+
+test:
+  # Python imports
+  imports:
+    - easyaccess
+
+about:
+  home: https://github.com/mgckind/easyaccess
+  license: University of Illinois/NCSA Open Source License
+  summary: 'Python command line interpreter to access DES Oracle database'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
Title should be self explanatory here. The only piece of real code is the `meta.yaml` file, which contains a few build procedures and dependencies.
