### PR TITLE
Restructuring dbnames

### DIFF
--- a/easyaccess/config_ea.py
+++ b/easyaccess/config_ea.py
@@ -185,7 +185,7 @@ def get_desconfig(desfile, db, verbose=True, user=None, pw1=None):
 
     if db not in databases and not config.has_section(db):
         check_db = input(
-            '\nDB entered is not dessci, desoper, destest or desdr '
+            '\nDB entered is not %s'%databases
             'or in DES_SERVICE file, continue anyway [y]/n\n')
         if check_db in ('n', 'N', 'no', 'No', 'NO', 'nO'):
             sys.exit(0)

--- a/easyaccess/config_ea.py
+++ b/easyaccess/config_ea.py
@@ -184,9 +184,9 @@ def get_desconfig(desfile, db, verbose=True, user=None, pw1=None):
     databases = ['db-desoper', 'db-dessci', 'db-destest', 'db-desdr']
 
     if db not in databases and not config.has_section(db):
-        check_db = input(
-            '\nDB entered is not %s'%databases
-            'or in DES_SERVICE file, continue anyway [y]/n\n')
+        msg = '\nDB entered is not %s '%databases
+        msg += 'or in DES_SERVICE file, continue anyway [y]/n\n'
+        check_db = input(msg)
         if check_db in ('n', 'N', 'no', 'No', 'NO', 'nO'):
             sys.exit(0)
 

--- a/easyaccess/config_ea.py
+++ b/easyaccess/config_ea.py
@@ -181,18 +181,19 @@ def get_desconfig(desfile, db, verbose=True, user=None, pw1=None):
         if verbose:
             print()
 
-    databases = ['db-desoper', 'db-dessci', 'db-destest', 'db-desdr']
+    databases = ['db-dessci', 'db-desdr', 'db-destest', 'db-desoper']
 
     if db not in databases and not config.has_section(db):
-        msg = '\nDB entered is not %s '%databases
-        msg += 'or in DES_SERVICE file, continue anyway [y]/n\n'
+        msg = '\nDatabase entered is not in %s '%databases
+        msg += 'or in DES_SERVICE file, continue anyway? [y]/n\n'
         check_db = input(msg)
-        if check_db in ('n', 'N', 'no', 'No', 'NO', 'nO'):
+        if check_db.lower() in ('n', 'no'):
             sys.exit(0)
 
+    # Add the default databases
     if not config.has_section(db):
         if verbose:
-            print('\nAdding section %s to des_service file\n' % db)
+            print('\nAdding section %s to DES_SERVICES file\n' % db)
         configwrite = True
         if db == 'db-dessci':
             kwargs = {'host': server_desdm, 'port': port_n, 'service_name': 'dessci'}
@@ -242,6 +243,9 @@ def get_desconfig(desfile, db, verbose=True, user=None, pw1=None):
                     print(value)
                     if value.args[0].code == 1017:
                         pass
+                    if value.args[0].code == 12514:
+                        print("Check that database '%s' exists\n"%db)
+                        sys.exit(0)
                     else:
                         sys.exit(0)
             if good:

--- a/easyaccess/eaparser.py
+++ b/easyaccess/eaparser.py
@@ -75,8 +75,7 @@ def get_args(config_file):
         "-s",
         "--db",
         dest="db",
-        choices=["dessci", "desoper", "destest", "desdr", "decade"],
-        help="Override database name [dessci,desoper,destest,desdr]",
+        help="Override database name [e.g., dessci, desoper, destest, desdr]",
     )
     parser.add_argument(
         "-q",

--- a/easyaccess/eaparser.py
+++ b/easyaccess/eaparser.py
@@ -75,7 +75,7 @@ def get_args(config_file):
         "-s",
         "--db",
         dest="db",
-        choices=["dessci", "desoper", "destest", "desdr"],
+        choices=["dessci", "desoper", "destest", "desdr", "decade"],
         help="Override database name [dessci,desoper,destest,desdr]",
     )
     parser.add_argument(

--- a/easyaccess/easyaccess.py
+++ b/easyaccess/easyaccess.py
@@ -49,6 +49,7 @@ except ImportError:
 positive = ['yes', 'y', 'true', 't', 'on']
 negative = ['no', 'n', 'false', 'f', 'off']
 input_options = ', '.join([i[0]+'/'+i[1] for i in zip(positive, negative)])
+dbnames = ('dessci', 'desoper', 'destest', 'desdr')
 
 # commands not available in public DB
 NOT_PUBLIC = ['add_comment', 'append_table', 'change_db', 'execproc',
@@ -930,7 +931,7 @@ Connected as {user} to {db}.
 
     def get_tables_names(self):
 
-        if self.dbname in ('dessci', 'desoper', 'destest', 'desdr'):
+        if self.dbname in dbnames:
             query = """
             select table_name from DES_ADMIN.CACHE_TABLES
             union select table_name from user_tables


### PR DESCRIPTION
This PR is meant to allow access to `decade`. It originally sought to:
* Add `decade` to the list of allowed databases.
* To define the list of allowed databases in one place (#169)
However, after some consideration, the restriction on database names was removed from the parser.